### PR TITLE
[Fix]task_spec.rbの修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :completed_task do
+      status { :done }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
-    deadline { Random.rand(from..to).strftime("%-m/%d %-H:%M") }
+    deadline { Random.rand(from..to) }
 
     trait :completed_task do
       status { :done }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
-    deadline { Random.rand(from..to) }
+    deadline { Random.rand(from..to).strftime("%-m/%d %-H:%M") }
 
     trait :completed_task do
       status { :done }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,5 +58,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # 
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
+  let(:project) { FactoryBot.create(:project) }
+  let(:task) { FactoryBot.create(:task, project_id: project.id)}
+  let(:completed_task) { FactoryBot.create(:task, :completed_task, project_id: project.id) }
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
@@ -15,8 +16,6 @@ RSpec.describe 'Task', type: :system do
 
       xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
         click_link 'View Todos'
         expect(page).to have_content task.title
@@ -30,7 +29,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -46,8 +44,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -61,20 +57,16 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        expect(find('.task_list')).to have_content task.deadline.strftime('%-m/%d %-H:%M')
         expect(current_path).to eq project_tasks_path(project)
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'
@@ -85,14 +77,12 @@ RSpec.describe 'Task', type: :system do
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
-        visit edit_project_task_path(project, task)
+        visit edit_project_task_path(project, completed_task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
-        expect(current_path).to eq project_task_path(project, task)
+        expect(current_path).to eq project_task_path(project, completed_task)
       end
     end
   end
@@ -100,13 +90,12 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskが削除されること' do
+        task
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(page).not_to have_selector 'td', text: task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe 'Task', type: :system do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_selector 'td', text: task.title
+        within('.task_list') do
+          expect(page).not_to have_content task.title
+        end
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: task.deadline
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content task.deadline.strftime('%-m/%d %-H:%M')
+        expect(find('.task_list')).to have_content short_time(task.deadline)
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
-  let(:project) { FactoryBot.create(:project) }
-  let(:task) { FactoryBot.create(:task, project_id: project.id)}
-  let(:completed_task) { FactoryBot.create(:task, :completed_task, project_id: project.id) }
+  let(:project) { create(:project) }
+  let(:task) { create(:task, project_id: project.id)}
+  let(:completed_task) { create(:task, :completed_task, project_id: project.id) }
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
@@ -56,7 +56,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit project_path(project)
         click_link 'View Todos'
+        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   let(:project) { create(:project) }
-  let(:task) { create(:task, project_id: project.id)}
+  let(:task) { create(:task, project_id: project.id) }
   let(:completed_task) { create(:task, :completed_task, project_id: project.id) }
   describe 'Task一覧' do
     context '正常系' do
@@ -56,10 +56,10 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         visit edit_project_task_path(project, task)
-        fill_in 'Deadline', with: Time.current
+        fill_in 'Deadline', with: task.deadline
         click_button 'Update Task'
         click_link 'Back'
         expect(find('.task_list')).to have_content task.deadline.strftime('%-m/%d %-H:%M')


### PR DESCRIPTION
[概要]
## 修正内容
- インスタンス変数の代わりに、let文を使用。
- `spec/factories/tasks.rb`でtrait文を用い、タスクが完了済みのテストデータを作成。
- `タスクが削除されること`のテストが成功するように修正。

## 未修正のテスト
- 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること'、
- 'Taskを編集した場合、一覧画面で編集後の内容が表示されること'